### PR TITLE
chore: fix gradle vfs watch properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.vs.watch=true
+org.gradle.vfs.watch=true
 
 # Hint by https://docs.gradle.org/current/userguide/performance.html#increase_the_heap_size
 # Otherwise, one gets "Java heap space" errors.


### PR DESCRIPTION

Closes N/A

Change `org.gradle.vs.watch=true` to `org.gradle.vfs.watch=true`. Fixed a small typo in the `gradle.properties`. See https://docs.gradle.org/current/userguide/file_system_watching.html for more information.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
